### PR TITLE
Implement Snyk in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@4.7.0
+  snyk: snyk/snyk@1.1.2
 
 jobs:
   test:
@@ -20,6 +21,7 @@ jobs:
       - run:
           command: yarn run test
           name: Run tests
+      - snyk/scan
 
 workflows:
   version: 2
@@ -28,3 +30,4 @@ workflows:
       - test:
           context:
             - "Docker Hub"
+            - "snyk"


### PR DESCRIPTION
Add [Snyk](snyk.io) to CI flow. This checks our dependencies for security vulnerabilities on each push and will fail the build if any are found. Makes use of the [Snyk Orb](https://circleci.com/developer/orbs/orb/snyk/snyk)