### PR TITLE
Fix lint step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
       - node/install-packages:
           pkg-manager: yarn
       - run:
-          command: yarn run test
+          command: yarn lint
           name: Run linting
       - run:
-          command: yarn run test
+          command: yarn test
           name: Run tests
       - snyk/scan
 


### PR DESCRIPTION
This command was implemented incorrectly. It was just running the test suite a second time.